### PR TITLE
Speedup countries

### DIFF
--- a/app/controllers/spree/api/ams/countries_controller.rb
+++ b/app/controllers/spree/api/ams/countries_controller.rb
@@ -9,6 +9,12 @@ module Spree
         def index
           @countries = Country.accessible_by(current_ability, :read)
                               .includes(:states).order(:name)
+
+          isos = params[:isos]
+          isos = isos.split ',' if isos.is_a?(String)
+
+          @countries = @countries.where(iso: isos) if isos.present?
+
           respond_with @countries
         end
 

--- a/app/controllers/spree/api/ams/countries_controller.rb
+++ b/app/controllers/spree/api/ams/countries_controller.rb
@@ -7,7 +7,8 @@ module Spree
 
         # We don't need this paginated.
         def index
-          @countries = Country.accessible_by(current_ability, :read).order('name ASC')
+          @countries = Country.accessible_by(current_ability, :read)
+                              .includes(:states).order(:name)
           respond_with @countries
         end
 

--- a/app/serializers/spree/state_serializer.rb
+++ b/app/serializers/spree/state_serializer.rb
@@ -4,9 +4,8 @@ module Spree
 
     attributes  :id,
                 :name,
-                :abbr
-
-    has_one :country, include: false
+                :abbr,
+                :country_id
 
   end
 end


### PR DESCRIPTION
- Use `@countries.includes(:states)` to avoid n+1 queries on states
- Drop the `has_one :country` on the `StateSerializer` and replace with `attribute :country_id` to avoid n+1 queries for the country
- Including all the countries might not be needed in most cases, so it's possible to add a query param to filter by country codes (eg.: `api/ams/countries?isos[]=DE&isos[]=CH&isos[]=AT`)

Doing the first two brings down load time from > 30s to ~5s, the last example takes < 100ms.

Related to issue #11.
